### PR TITLE
Adds session duration fields in users

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -30,6 +30,7 @@ class Api::V1::SessionsController < Api::BaseController
   def after_terminate_session(session)
     Sessions::Rewards.reward(session)
     Sessions::WalletTransaction.create(session)
+    Sessions::Duration.update_user_session_duration(current_user, session)
     Wallet::Transactions.update_user_balance(current_user, session.rewards)
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,4 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :email, :mobile, :profile_picture_url, :wallet_balance
+  attributes :id, :name, :email, :mobile, :profile_picture_url, :wallet_balance,
+             :home_duration_in_seconds, :away_duration_in_seconds
 end

--- a/db/migrate/20200402205623_add_session_total_duration_on_users.rb
+++ b/db/migrate/20200402205623_add_session_total_duration_on_users.rb
@@ -1,0 +1,6 @@
+class AddSessionTotalDurationOnUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :home_duration_in_seconds, :integer, null: false, default: 0
+    add_column :users, :away_duration_in_seconds, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_01_212538) do
+ActiveRecord::Schema.define(version: 2020_04_02_205623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,8 @@ ActiveRecord::Schema.define(version: 2020_04_01_212538) do
     t.decimal "lng", precision: 10, scale: 6
     t.string "city"
     t.string "country_name"
+    t.integer "home_duration_in_seconds", default: 0, null: false
+    t.integer "away_duration_in_seconds", default: 0, null: false
     t.index ["auth_token"], name: "index_users_on_auth_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"

--- a/lib/sessions/duration.rb
+++ b/lib/sessions/duration.rb
@@ -3,5 +3,18 @@ module Sessions
     def self.in_minutes(session)
       ((session.end_time - session.start_time) / 1.minutes).round
     end
+
+    def self.in_seconds(session)
+      (session.end_time - session.start_time).round
+    end
+
+    def self.update_user_session_duration(user, session)
+      seconds = self.in_seconds(session)
+      if session.session_type == 'home'
+        user.update_columns(home_duration_in_seconds: user.home_duration_in_seconds + seconds)
+      elsif session.session_type == 'away'
+        user.update_columns(away_duration_in_seconds: user.away_duration_in_seconds + seconds)
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/leader_board_spec.rb
+++ b/spec/requests/api/v1/leader_board_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'LeaderBoard', type: :request do
       end
 
       context 'when user is in the top list' do
-        let(:user) { FactoryBot.create(:user, wallet_balance: 35.0) }
+        let(:user) { FactoryBot.create(:user, wallet_balance: 35.0, auth_token: 'test_token') }
         let(:expected_response) do
           {
             'top_users' => [
@@ -91,7 +91,7 @@ RSpec.describe 'LeaderBoard', type: :request do
             }
           }
         end
-        let(:user) { FactoryBot.create(:user, wallet_balance: 0.0) }
+        let(:user) { FactoryBot.create(:user, wallet_balance: 0.0, auth_token: 'test_token') }
 
         it 'should return the right list and the right user rank' do
           stub_const("LeaderBoard", LeaderBoard, transfer_nested_constants: true)

--- a/spec/requests/api/v1/users_spec.rb
+++ b/spec/requests/api/v1/users_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe 'Users', type: :request do
           "mobile" => user.mobile,
           "name" => user.name,
           "profile_picture_url" => user.profile_picture_url,
-          "wallet_balance" => "0.0"
+          "wallet_balance" => "0.0",
+          "home_duration_in_seconds" => 0,
+          "away_duration_in_seconds" => 0
         }
       end
 


### PR DESCRIPTION
**Why**
We need to show total duration of home-session by an user.

**What**
Added two fields `home_duration_in_seconds` and `away_duration_in_seconds` in `users` table. The motivation behind it is to avoid performing the computation on the fly with every new request. The fact that new sessions would not emerge frequently, supports the argument that these fields would not be updated on a very regular basis. Such lazy computation might save us some processing power.

So everytime a session ends, the appropriate field in the table (depending upon whether the session is home / away) is updated to its recent value.